### PR TITLE
Runner.js to manage suicides in case of possible mis-behaviour

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var {ethCall, ethSend, getEvents} = require("./src/ethCall")
 var {getAbi, deployContracts} = require("./src/compileContracts")
 var getContractAt = require("./src/getContractAt")
 var web3 = require("./src/signed-web3")
+var {dieIfCriticalError} = require("./src/runner")
 
 var app = express();
 
@@ -50,6 +51,7 @@ function responsePromise(res, handler, args) {
         res.send(result)
     }).catch(e => {
         res.send({errors: [e.toString()]})
+        dieIfCriticalError(e)
     })
 }
         

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "restling": "^0.9.1",
     "serve-favicon": "~2.3.0",
     "solc": "^0.4.9",
-    "web3": "^0.18.2"
+    "web3": "0.18.2"
   },
   "devDependencies": {
     "cli-table": "^0.3.1",

--- a/src/ethCall.js
+++ b/src/ethCall.js
@@ -1,6 +1,7 @@
 const _ = require("lodash")
 const web3 = require("./signed-web3")
 const Promise = require("bluebird")
+const {bump} = require("./src/runner")
 
 const SolidityEvent = require("web3/lib/web3/event.js")
 const SolidityCoder = require("web3/lib/solidity/coder.js")
@@ -109,6 +110,8 @@ function transactionPromise(from, to, abi, getTransaction) {
                         clearTimeout(timeoutHandle)
                         filter.stopWatching()
                         done({srcBalanceBefore, dstBalanceBefore, tx, tr})
+                    } else {
+                        bump()      // prefer to die if too many waiting transactions
                     }
                 })
                 const timeoutHandle = setTimeout(() => {

--- a/src/ethCall.js
+++ b/src/ethCall.js
@@ -1,7 +1,7 @@
 const _ = require("lodash")
 const web3 = require("./signed-web3")
 const Promise = require("bluebird")
-const {bump} = require("./src/runner")
+const {bump} = require("./runner")
 
 const SolidityEvent = require("web3/lib/web3/event.js")
 const SolidityCoder = require("web3/lib/solidity/coder.js")

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,0 +1,47 @@
+/**
+ * runner.js - more like STOP running amok
+ *
+ * May be useful if there is a process watcher (e.g. pm2) that restarts the process if it exits
+ **/
+
+// TODO: parameters from process.env and process.argv
+const enabled = true
+const survivableBumpCount = 10
+const bumpCooldownMs = 1000
+const criticalErrors = [
+    "Nonce too low"
+]
+
+function dieAfterMs(delayMs) {
+    setTimeout(die, delayMs)
+}
+
+function die() {
+    if (enabled) {
+        process.exit(1)
+    }
+}
+
+var lastBump = 0
+var bumpCount = 0
+function bump() {
+    const now = +new Date()
+    if (now - lastBump > bumpCooldownMs) {
+        bumpCount = 0
+    }
+    bumpCount++
+    if (bumpCount > survivableBumpCount) {
+        dieAfterMs(1)
+    }
+}
+
+function dieIfCriticalError(e) {
+    const errorMessage = e.message ? e.message : e.toString()
+    criticalErrors.forEach(err => {
+        if (errorMessage.contains(err)) {
+            dieAfterMs(1)
+        }
+    })
+}
+
+module.exports = { die, dieAfterMs, bump, dieIfCriticalError }


### PR DESCRIPTION
Some circumstances seem to require manual restarts: "Nonce too low", "waiting for transaction..." piling etc.

This patch is an attempt to automate that, assuming pm2 will restart exiting processes

Made a pull request to get feedback.